### PR TITLE
fix py::doc init

### DIFF
--- a/src/specialcf.cpp
+++ b/src/specialcf.cpp
@@ -97,10 +97,10 @@ namespace ngfem {
 
 
 PYBIND11_MODULE(special_functions, m) {
-    py::doc doc_string = "Same as in scipy.special";
+    py::doc doc_string("Same as in scipy.special");
     ExportPythonSpecialCF(m, "gammaln", gammaln, doc_string);
 
-    py::doc docu = "Same as in scipy.special, except that the order of the arguments is swapped.";
+    py::doc docu("Same as in scipy.special, except that the order of the arguments is swapped.");
     ExportPythonSpecialCF(m, "iv",  iv,  py::arg("z"), py::arg("v")=0, docu);
     ExportPythonSpecialCF(m, "ive", ive, py::arg("z"), py::arg("v")=0, docu);
     ExportPythonSpecialCF(m, "jv",  jv,  py::arg("z"), py::arg("v")=0, docu);


### PR DESCRIPTION
Hello!
I am getting the compilation error 
`specialcf.cpp:100:26: error: conversion from 'const char [...]' to non-scalar type 'pybind11::doc' requested`
I fixed it by using the constructor directly.